### PR TITLE
fix: add truthy check before calling 'replace'

### DIFF
--- a/src/json-ld.component.ts
+++ b/src/json-ld.component.ts
@@ -15,7 +15,7 @@ export class JsonLdComponent implements OnChanges {
   }
 
   getSafeHTML(value: {}) {
-    const json = JSON.stringify(value, null, 2).replace(/\//g, '\\/');
+    const json = value ? JSON.stringify(value, null, 2).replace(/\//g, '\\/') : '';
     const html = `<script type="application/ld+json">${json}</script>`;
     return this.sanitizer.bypassSecurityTrustHtml(html);
   }


### PR DESCRIPTION
Fixes this error:

```
ERROR TypeError: Cannot read property 'replace' of undefined
    at JsonLdComponent._5b1‍.r.JsonLdComponent.getSafeHTML (C:\Builds\estate-sales\Web\node_modules\ngx-json-ld\ngx-json-ld.umd.js:35:67)
    at JsonLdComponent._5b1‍.r.JsonLdComponent.ngOnChanges (C:\Builds\estate-sales\Web\node_modules\ngx-json-ld\ngx-json-ld.umd.js:24:28)
    at checkAndUpdateDirectiveInline (C:\Builds\estate-sales\Web\node_modules\packages\core\esm5\src\view\provider.js:249:6)
    at checkAndUpdateNodeInline (C:\Builds\estate-sales\Web\node_modules\packages\core\esm5\src\view\view.js:482:9)
    at checkAndUpdateNode (C:\Builds\estate-sales\Web\node_modules\packages\core\esm5\src\view\view.js:425:2)
    at prodCheckAndUpdateNode (C:\Builds\estate-sales\Web\node_modules\@angular\core\bundles\core.umd.js:14633:5)
    at Object.eval [as updateDirectives] (ng:///SharedModule/SaleRowComponent.ngfactory.js:348:5)
    at Object.updateDirectives (C:\Builds\estate-sales\Web\node_modules\packages\core\esm5\src\view\services.js:78:17)
    at checkAndUpdateView (C:\Builds\estate-sales\Web\node_modules\packages\core\esm5\src\view\view.js:391:14)
    at callViewAction (C:\Builds\estate-sales\Web\node_modules\packages\core\esm5\src\view\view.js:742:14)
```